### PR TITLE
fix test typo

### DIFF
--- a/test/test.es5.js
+++ b/test/test.es5.js
@@ -64,7 +64,7 @@ tressa.assert(new List(1) instanceof List, 'new List is an instanceof List');
 tressa.assert(new List(2) instanceof Array, 'new List is an instanceof Array');
 var l = new List(3);
 tressa.assert(l.length === 1 && l[0] === 3, 'constructor pushes an entry');
-tressa.assert(l.push(4) === l && l.length === 2 && l.join('3,4'), 'method override works');
+tressa.assert(l.push(4) === l && l.length === 2 && l.join() === '3,4', 'method override works');
 
 let SecondLevel = function (_List) {
   _inherits(SecondLevel, _List);
@@ -90,5 +90,5 @@ tressa.assert(new SecondLevel(2) instanceof List, 'new SecondLevel is an instanc
 tressa.assert(new SecondLevel(3) instanceof Array, 'new SecondLevel is an instanceof Array');
 var s = new SecondLevel(4);
 tressa.assert(s.length === 1 && s[0] === 4, 'constructor pushes an entry');
-tressa.assert(s.push(5) === s && s.length === 2 && s.join('4,5'), 'inherited override works');
+tressa.assert(s.push(5) === s && s.length === 2 && s.join() === '4,5', 'inherited override works');
 tressa.assert(s.method() === s, 'new method works');

--- a/test/test.js
+++ b/test/test.js
@@ -19,7 +19,7 @@ tressa.assert(new List(1) instanceof List, 'new List is an instanceof List');
 tressa.assert(new List(2) instanceof Array, 'new List is an instanceof Array');
 var l = new List(3);
 tressa.assert(l.length === 1 && l[0] === 3, 'constructor pushes an entry');
-tressa.assert(l.push(4) === l && l.length === 2 && l.join('3,4'), 'method override works');
+tressa.assert(l.push(4) === l && l.length === 2 && l.join() === '3,4', 'method override works');
 
 class SecondLevel extends List {
   method() {
@@ -32,5 +32,5 @@ tressa.assert(new SecondLevel(2) instanceof List, 'new SecondLevel is an instanc
 tressa.assert(new SecondLevel(3) instanceof Array, 'new SecondLevel is an instanceof Array');
 var s = new SecondLevel(4);
 tressa.assert(s.length === 1 && s[0] === 4, 'constructor pushes an entry');
-tressa.assert(s.push(5) === s && s.length === 2 && s.join('4,5'), 'inherited override works');
+tressa.assert(s.push(5) === s && s.length === 2 && s.join() === '4,5', 'inherited override works');
 tressa.assert(s.method() === s, 'new method works');


### PR DESCRIPTION
`assert(list.join('3,4'))` → `assert(list.join() === '3,4')`